### PR TITLE
Implement HOC `withAuth` to restrict page access based on user roles

### DIFF
--- a/app/HistoryTracker.tsx
+++ b/app/HistoryTracker.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { useHistoryStore } from '@/store/history.store';
+
+export default function RouteTracker() {
+    const pathname = usePathname();
+    const push = useHistoryStore((state) => state.push);
+
+    useEffect(() => {
+        push(pathname);
+    }, [pathname, push]);
+
+    return null;
+}

--- a/app/configuracion/page.tsx
+++ b/app/configuracion/page.tsx
@@ -14,8 +14,9 @@ import { AlertCircle, Check, Save, User, Database, FileText, Shield, Users } fro
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { useToast } from "@/hooks/use-toast"
 import Link from "next/link"
+import { withAuth } from "@/hoc/withAuth";
 
-export default function ConfiguracionPage() {
+function ConfiguracionPage() {
   const [activeTab, setActiveTab] = useState("general")
   const [saveSuccess, setSaveSuccess] = useState(false)
   const { toast } = useToast()
@@ -463,3 +464,5 @@ export default function ConfiguracionPage() {
     </AppLayout>
   )
 }
+
+export default withAuth(ConfiguracionPage, 'configuracion')

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -22,8 +22,9 @@ import { FinantialOperationKpis } from "@/components/dashboard/finantial-operati
 import { SubsidiaryMetricsGrid } from "@/components/subsidiary/subsidiary-metrics"
 import { useDashboard } from "@/hooks/services/dashboard/use-dashboard"
 import { SubsidiaryPerformanceList } from "@/components/subsidiary/subsidiary-performance-list"
+import {withAuth} from "@/hoc/withAuth";
 
-export default function DashboardPage() {
+function DashboardContent() {
   const today = new Date()
   const startDayOfMonth = format(startOfMonth(today), "yyyy-MM-dd")
   const endDayOfMonth = format(endOfMonth(today), "yyyy-MM-dd")
@@ -185,3 +186,5 @@ export default function DashboardPage() {
     </AppLayout>
   )
 }
+
+export default withAuth(DashboardContent, "dashboard")

--- a/app/gastos/page.tsx
+++ b/app/gastos/page.tsx
@@ -39,6 +39,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useExpenses, useSaveExpense } from "@/hooks/services/expenses/use-expenses"
 import { categoriasGasto } from "@/lib/data"  // tu lista de categorías
 import { toast } from "sonner"
+import { withAuth } from "@/hoc/withAuth";
 
 
 // Métodos de pago disponibles
@@ -62,7 +63,7 @@ const getCategoryColor = (categoryName: string): string => {
   return colorMap[categoryName] || "bg-gray-500"
 }
 
-export default function GastosPage() {
+function GastosPage() {
   const [selectedSucursalId, setSelectedSucursalId] = useState<string>("")
   const [gastos, setGastos] = useState<Expense[]>([])
   const [categorias, setCategorias] = useState<ExpenseCategory[]>([])
@@ -543,3 +544,5 @@ export default function GastosPage() {
     </AppLayout>
   )
 }
+
+export default withAuth(GastosPage, "gastos")

--- a/app/ingresos/page.tsx
+++ b/app/ingresos/page.tsx
@@ -17,8 +17,9 @@ import { ShipmentDetailDialog } from "@/components/modals/shipment-detial-dialog
 import { NewIncome } from "@/lib/types"
 import { getLastWeekRange } from "@/utils/date.utils"
 import { TrackingValidationButton } from "@/components/modals/tracking-validation-button"
+import { withAuth } from "@/hoc/withAuth";
 
-export default function IngresosPage() {
+function IngresosPage() {
   const [selectedSucursalId, setSelectedSucursalId] = useState<string>("")
   const [{ fromDate, toDate }, setRange] = useState(getLastWeekRange())
 
@@ -450,3 +451,5 @@ export default function IngresosPage() {
     </AppLayout>
   )
 }
+
+export default withAuth(IngresosPage, "ingresos");

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google"
 import "@/styles/globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { TooltipProvider } from "@/components/ui/tooltip"
+import HistoryTracker from "@/app/HistoryTracker";
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -27,9 +28,10 @@ export default function RootLayout({
     <html lang="es" suppressHydrationWarning>
       <body className={inter.className} suppressHydrationWarning>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
-          <TooltipProvider>
-            {children}
-          </TooltipProvider>
+            <TooltipProvider>
+                <HistoryTracker/>
+                {children}
+            </TooltipProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/app/operaciones/cargas/page.tsx
+++ b/app/operaciones/cargas/page.tsx
@@ -15,8 +15,9 @@ import { SucursalSelector } from "@/components/sucursal-selector";
 import { Charge, ChargeShipment } from "@/lib/types";
 import { ChargeShipmentDetailDialog } from "@/components/modals/charge-shipment-detail-dialog";
 import { useCharges } from "@/hooks/services/shipments/use-shipments";
+import {withAuth} from "@/hoc/withAuth";
 
-export default function ChargesWithKpis() {
+function ChargesWithKpis() {
   const { charges, isLoading, mutate } = useCharges();
     const [selectedShipments, setSelectedShipments] = useState<ChargeShipment[] | null>(null);
     const [selectedSucursalId, setSelectedSucursalId] = useState<string | undefined>(undefined)
@@ -155,3 +156,5 @@ export default function ChargesWithKpis() {
         </AppLayout>
     );
 }
+
+export default withAuth(ChargesWithKpis, 'operaciones');

--- a/app/operaciones/choferes/page.tsx
+++ b/app/operaciones/choferes/page.tsx
@@ -5,6 +5,7 @@ import { columns } from "./columns"
 import { Button } from "@/components/ui/button"
 import { PlusCircle } from "lucide-react"
 import { NewDriverDialog } from "@/components/modals/new-driver-modal"
+import { withAuth } from "@/hoc/withAuth";
 
 const data = [
   {
@@ -24,7 +25,7 @@ const data = [
   // Add more sample data as needed
 ]
 
-export default function DriversPage() {
+function DriversPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -39,3 +40,5 @@ export default function DriversPage() {
     </div>
   )
 }
+
+export default withAuth(DriversPage, 'operaciones');

--- a/app/operaciones/consolidados/page.tsx
+++ b/app/operaciones/consolidados/page.tsx
@@ -18,8 +18,9 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { getFedexStatus } from "@/lib/services/consolidated";
+import { withAuth } from "@/hoc/withAuth";
 
-export default function ConsolidatedWithKpis() {
+function ConsolidatedWithKpis() {
   const today = new Date()
   const startDayOfMonth = format(startOfMonth(today), "yyyy-MM-dd")
   const endDayOfMonth = format(endOfMonth(today), "yyyy-MM-dd")
@@ -326,3 +327,5 @@ export default function ConsolidatedWithKpis() {
     </AppLayout>
   );
 }
+
+export default withAuth(ConsolidatedWithKpis, 'operaciones');

--- a/app/operaciones/envios/page.tsx
+++ b/app/operaciones/envios/page.tsx
@@ -24,9 +24,10 @@ import KPIShipmentCards from "@/components/operaciones/envios/KpiCards"
 import { NewShipmentDialog } from "@/components/modals/new-shipment-modal"
 import { toast } from "sonner"
 import { ShipmentWizardModal } from "@/components/modals/import-shipment-wizard"
+import { withAuth } from "@/hoc/withAuth";
 
 
-export default function ShipmentsPage() {
+function ShipmentsPage() {
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false)
   const [selectedShipment, setSelectedShipment] = useState<Shipment | null>(null)
   const { shipments, isLoading, mutate } = useShipments()
@@ -179,3 +180,5 @@ export default function ShipmentsPage() {
     </AppLayout>
   )
 }
+
+export default withAuth(ShipmentsPage, 'operaciones')

--- a/app/operaciones/monitoreo/page.tsx
+++ b/app/operaciones/monitoreo/page.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table"
 import { ShipmentType, ShipmentStatusType, Priority } from "@/lib/types"
 import { AppLayout } from "@/components/app-layout"
+import { withAuth } from '@/hoc/withAuth';
 
 interface Shipment {
   id: string
@@ -87,7 +88,7 @@ export const getStatusVariant = (status: ShipmentStatusType) => {
   }
 
 
-export default function ShipmentMonitoringDashboard() {
+function ShipmentMonitoringDashboard() {
   const [selectedShipment, setSelectedShipment] = useState<Shipment | null>(null)
   const [searchTerm, setSearchTerm] = useState("")
   const [activeTab, setActiveTab] = useState<ShipmentStatusType | 'all'>('all')
@@ -377,3 +378,5 @@ export default function ShipmentMonitoringDashboard() {
     </AppLayout>
   )
 }
+
+export default withAuth(ShipmentMonitoringDashboard, 'operaciones')

--- a/app/operaciones/recolecciones/page.tsx
+++ b/app/operaciones/recolecciones/page.tsx
@@ -24,8 +24,9 @@ import { useCollections } from "@/hooks/services/collections/use-collections"
 import CollectionForm from "@/components/modals/collection-form"
 import type { Collection } from "@/lib/types"
 import { getSucursales } from "@/lib/data"
+import { withAuth } from "@/hoc/withAuth";
 
-export default function RecoleccionesPage() {
+function RecoleccionesPage() {
   // Unificar nombre de variable y usar null como estado inicial
   const [selectedSucursalId, setSelectedSucursalId] = useState<string | null>(null)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
@@ -152,3 +153,5 @@ export default function RecoleccionesPage() {
     </AppLayout>
   )
 }
+
+export default withAuth(RecoleccionesPage, 'operaciones')

--- a/app/operaciones/rutas/page.tsx
+++ b/app/operaciones/rutas/page.tsx
@@ -3,6 +3,7 @@
 import { DataTable } from "@/components/data-table/data-table"
 import { columns } from "./columns"
 import { AppLayout } from "@/components/app-layout"
+import { withAuth } from "@/hoc/withAuth";
 
 const data = [
   {
@@ -35,7 +36,7 @@ const data = [
   // Añade más rutas aquí...
 ]
 
-export default function RoutesPage() {
+function RoutesPage() {
   return (
     <AppLayout>
       <div className="space-y-6">
@@ -45,3 +46,4 @@ export default function RoutesPage() {
   )
 }
 
+export default withAuth(RoutesPage, 'operaciones');

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -13,12 +13,12 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar"
 
-import { sidebarMenu } from "@/lib/constants"
 import { NavUser } from "./nav-user"
 import Image from "next/image"
 import { NavMenu } from "./nav-menu"
 import { NavSecondary } from "./nav-secondary"
 import { User } from "@/lib/types"
+import {useFilteredMenu} from "@/hooks/use-filtered-menu";
 
 interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
   user: User
@@ -28,6 +28,8 @@ interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
 }
 
 export function AppSidebar({ user, ...props }: AppSidebarProps) {
+  const sidebarMenu: any = useFilteredMenu();
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarContent>

--- a/hoc/withAuth.tsx
+++ b/hoc/withAuth.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useEffect, ComponentType } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+import { useAuthStore } from '@/store/auth.store';
+import { useHistoryStore } from '@/store/history.store';
+import { UserRole } from '@/lib/types';
+import { allowedPageRoles } from '@/lib/access/allowed-page-roles';
+
+type PageName = keyof typeof allowedPageRoles;
+
+export function withAuth<P extends object>(Component: ComponentType<P>, access?: PageName | UserRole[]) {
+    return function AuthenticatedComponent(props: P) {
+        const { isAuthenticated, user, hasHydrated } = useAuthStore();
+        const router = useRouter();
+        const pathname = usePathname();
+
+        const previous = useHistoryStore((state) => {
+            const h = state.history;
+            return h.length > 1 ? h[h.length - 2] : null;
+        });
+
+        const roles: UserRole[] = Array.isArray(access)
+            ? access as UserRole[]
+            : access
+                ? (allowedPageRoles[access as PageName] as UserRole[]) ?? []
+                : [];
+
+        useEffect(() => {
+            if (!hasHydrated) return;
+
+            // Si no está autenticado
+            if (!isAuthenticated) {
+                if (pathname !== '/login') {
+                    console.warn('No autenticado, redirigiendo a login');
+                    router.push('/login'); // push para permitir volver
+                }
+                return;
+            }
+
+            // Si el usuario aún no tiene rol (por retraso en la carga)
+            if (!user?.role) return;
+
+            const roleNotAllowed = roles.length > 0 && !roles.includes(user.role);
+
+            if (roleNotAllowed) {
+                if (previous && previous !== pathname) {
+                    console.warn(`Rol no permitido (${user.role}), regresando a la página anterior`);
+                    router.push(previous); // intenta volver a la anterior
+                } else {
+                    console.warn(`Rol no permitido (${user.role}), redirigiendo a /dashboard`);
+                    router.push('/dashboard'); // fallback
+                }
+            }
+        }, [hasHydrated, isAuthenticated, user?.role, roles, router, pathname, previous]);
+
+        if (!hasHydrated || !isAuthenticated || !user?.role) return null;
+
+        const isAllowed = roles.length === 0 || roles.includes(user.role);
+        if (!isAllowed) return null;
+
+        return <Component {...props} />;
+    };
+}

--- a/hooks/use-filtered-menu.tsx
+++ b/hooks/use-filtered-menu.tsx
@@ -1,0 +1,31 @@
+import {useAuthStore} from "@/store/auth.store";
+import {NavItem, sidebarMenu} from "@/lib/constants";
+
+export function useFilteredMenu() {
+    const role = useAuthStore((state) => state.user?.role);
+
+    function filterItems(items: any[]): (NavItem | null)[] {
+        return items
+            .map((item) => {
+                if (item.items) {
+                    const filteredSubitems = filterItems(item.items);
+                    if (filteredSubitems.length > 0) {
+                        return { ...item, items: filteredSubitems };
+                    }
+                    return null;
+                }
+
+                // Not defined Roles, display for all
+                if (!item.roles || item.roles.includes(role)) {
+                    return item;
+                }
+                return null;
+            })
+            .filter(Boolean);
+    }
+
+    return {
+        items: filterItems(sidebarMenu.items),
+        secondary: filterItems(sidebarMenu.secondary),
+    };
+}

--- a/lib/access/allowed-page-roles.ts
+++ b/lib/access/allowed-page-roles.ts
@@ -1,0 +1,10 @@
+export const allowedPageRoles = {
+    dashboard: ["admin", "superadmin", "user"],
+    sucursales: ["admin", "superadmin"],
+    operaciones: ["admin", "superadmin"],
+    mttoVehiculos: ["admin", "superadmin"],
+    gastos: ["admin", "user"],
+    ingresos: ["admin", "user"],
+    configuracion: ["admin", "superadmin"],
+    nomina: ["admin", "superadmin"],
+};

--- a/lib/access/types.ts
+++ b/lib/access/types.ts
@@ -1,0 +1,8 @@
+export type Role = "admin" | "superadmin" | "user"
+
+export interface RouteAccessEntry {
+    path: string
+    allowedRoles?: Role[]
+}
+
+export type RouteAccessConfig = Record<string, RouteAccessEntry>

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,10 +1,12 @@
 import { IconTruckLoading } from "@tabler/icons-react"
 import { BarChart3, PieChart, SettingsIcon, BuildingIcon, PackageIcon, TruckIcon, BriefcaseBusinessIcon, Truck, Wallet2Icon, ChartNoAxesCombinedIcon, DollarSignIcon, HomeIcon, HistoryIcon, PenToolIcon, PackagePlusIcon, MapIcon, MonitorCheckIcon } from "lucide-react"
+import { ElementType } from "react";
+import { allowedPageRoles } from "@/lib/access/allowed-page-roles";
 
 export interface NavItem {
     title: string
     href: string
-    icon: React.ElementType,
+    icon: ElementType,
     roles?: string[]
 }
 
@@ -15,10 +17,11 @@ export const sidebarMenu = {
       url: "/dashboard",
       icon: HomeIcon,
       isActive: false,
+      roles: allowedPageRoles.dashboard,
     },
-    { 
+    {
       title: "Administración",
-      url:"#",
+      url: "#",
       icon: BuildingIcon,
       isActive: false,
       items: [
@@ -26,8 +29,8 @@ export const sidebarMenu = {
           name: "Sucursales",
           url: "/sucursales",
           icon: BuildingIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.sucursales,
+          isActive: false,
         }
       ]
     },
@@ -41,45 +44,45 @@ export const sidebarMenu = {
           name: "Cargas",
           url: "/operaciones/cargas",
           icon: TruckIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.operaciones,
+          isActive: false,
         },
         {
           name: "Consolidados",
           url: "/operaciones/consolidados",
           icon: IconTruckLoading,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.operaciones,
+          isActive: false,
         },
         {
           name: "Envios",
           url: "/operaciones/envios",
           icon: PackageIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.operaciones,
+          isActive: false,
         },
         {
           name: "Monitoreo",
           url: "/operaciones/monitoreo",
           icon: MonitorCheckIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.operaciones,
+          isActive: false,
         },
         {
           name: "Recoleciones",
           url: "/operaciones/recolecciones",
           icon: PackagePlusIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.operaciones,
+          isActive: false,
         },
         {
           name: "Rutas",
           url: "/operaciones/rutas",
           icon: MapIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.operaciones,
+          isActive: false,
         },
-      ]
+      ],
     },
     {
       title: "Mtto. Vehículos",
@@ -91,17 +94,17 @@ export const sidebarMenu = {
           name: "Programación",
           url: "/programacion-mtto",
           icon: PenToolIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.mttoVehiculos,
+          isActive: false,
         },
         {
           name: "Historial",
           url: "/historial-mtto",
           icon: HistoryIcon,
-          roles: ["admin", "superadmin"],
-          isActive: false
+          roles: allowedPageRoles.mttoVehiculos,
+          isActive: false,
         },
-      ]
+      ],
     },
     {
       title: "Finanzas",
@@ -113,15 +116,15 @@ export const sidebarMenu = {
           name: "Ingresos",
           url: "/ingresos",
           icon: BarChart3,
-          permission: "ingresos:view",
+          roles: allowedPageRoles.ingresos, // del diccionario
         },
         {
           name: "Gastos",
           url: "/gastos",
           icon: PieChart,
-          permission: "gastos:view",
+          roles: allowedPageRoles.gastos,
         },
-      ]
+      ],
     },
     {
       title: "Reportes",
@@ -134,6 +137,7 @@ export const sidebarMenu = {
       url: "/nomina",
       icon: DollarSignIcon,
       isActive: false,
+      roles: allowedPageRoles.nomina,
     },
   ],
   secondary: [
@@ -142,6 +146,7 @@ export const sidebarMenu = {
       url: "/configuracion",
       icon: SettingsIcon,
       isActive: false,
+      roles: allowedPageRoles.configuracion,
     }
   ]
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -121,7 +121,7 @@ export type NewIncome = {
   }[]
 }
 
-type UserRole = "user" | "admin";
+export type UserRole = "user" | "admin" | "superadmin";
 
 export type User = {
   id?: string

--- a/store/auth.store.ts
+++ b/store/auth.store.ts
@@ -14,7 +14,7 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>()(
-  persist(
+  persist<AuthState>(
     (set) => ({
       user: null,
       token: null,

--- a/store/history.store.ts
+++ b/store/history.store.ts
@@ -1,0 +1,34 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface HistoryState {
+    history: string[];
+    push: (path: string) => void;
+    previous: () => string | null;
+}
+
+const MAX_HISTORY_LENGTH = 5;
+
+export const useHistoryStore = create<HistoryState>()(
+    persist<HistoryState>(
+        (set, get) => ({
+            history: [],
+            push: (path) => {
+                set((state) => {
+                    const last = state.history[state.history.length - 1];
+                    if (last === path) return {}; // evita duplicados consecutivos
+
+                    const newHistory = [...state.history, path].slice(-MAX_HISTORY_LENGTH);
+                    return { history: newHistory };
+                });
+            },
+            previous: () => {
+                const h = get().history;
+                return h.length > 1 ? h[h.length - 2] : null;
+            }
+        }),
+        {
+            name: 'history-storage',
+        }
+    )
+);


### PR DESCRIPTION
Se hace uso de el HOC, withAuth, se envuelven las paginas que necesitan estar protegidas, se pueden definir permisos directamente en la pagina, el archivo allowedRoles, ocn su nombre de pagina, si la ruta a la que el usuario intenta acceder esta fuera de su rol, la pagina redirige a la pagina anterior o dashboard, por eso se hace uso del state history en zustand, guarda los movimientos mas recientes en la navegacion para saber a que pagina volver. 